### PR TITLE
Continuous integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: generator-starknet-ci
+name: Build
 
 on: [push]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on: [push]
+
+jobs:
+  test-project-generation:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install the generator
+        run: npm i -g yo generator-starknet
+      - name: Install the expect utility
+        run: sudo apt-get install -y expect
+      - name: Run the generator
+        run: expect __tests__/generator.exp
+      - name: Check the project has been created
+        run: '[ -f "/home/runner/work/generator-starknet/generator-starknet/requirements.txt" ]'

--- a/__tests__/generator.exp
+++ b/__tests__/generator.exp
@@ -1,0 +1,19 @@
+#!/usr/bin/expect
+spawn yo starknet
+
+expect "the project name"
+send "test-project\r"
+
+expect "root directory"
+send "\r"
+
+expect "framework"
+send "\r"
+
+expect "ERC20"
+send "\r"
+
+expect "ERC721"
+send "\r"
+
+interact


### PR DESCRIPTION
Add a CI workflow that uses the generator to create a new project.
Uses all the default choices, and then tests that the project is correctly generated.

Currently, the project is not generated at all, so you might want to check the generator for a potential bug until this workflow passes.